### PR TITLE
Check Media URL instead of regular Base URL

### DIFF
--- a/Image/HtmlReplacer.php
+++ b/Image/HtmlReplacer.php
@@ -112,7 +112,7 @@ class HtmlReplacer
     private function isAllowedByImageUrl(string $imageUrl): bool
     {
         $imageUrl = trim($imageUrl);
-        $baseUrl = $this->url->getBaseUrl();
+        $baseUrl = $this->url->getBaseUrl(['_type' => UrlInterface::URL_TYPE_MEDIA]);
         if (preg_match('/^https?:\/\//', $imageUrl) && strpos($imageUrl, $baseUrl) === false) {
             return false;
         }


### PR DESCRIPTION
The check introduced in https://github.com/yireo/Yireo_NextGenImages/pull/6 checks the BaseURL.
When the Store Code is added to the URL (en `/nl`) the url doesn't match. 
By requesting the Media URL, the url does match.