### PR TITLE
Reduce I/O operation for high traffic server

### DIFF
--- a/Image/File.php
+++ b/Image/File.php
@@ -103,6 +103,14 @@ class File
     {
         try {
             $fileRead = $this->fileReadFactory->create($filePath, 'file');
+
+            $stat = $fileRead->stat();
+
+            if (isset($stat['size'])) {
+                return (int)$stat['size'] > 0;
+            }
+
+            // fallback if filesystem returns no stats
             return (bool)$fileRead->readAll();
         } catch (FileSystemException $fileSystemException) {
             return false;


### PR DESCRIPTION
Use stat to check if a file is not empty instead of loading the complete content.
If the file system does not support start we have a fallback call with "readAll".