### PR TITLE
Use `Magento\Framework\Filesystem`, to allow override by RemoteStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow file driver interface to be overwritten
 
 ## [0.2.11] - 26 October 2021
 ### Fixed

--- a/Image/File.php
+++ b/Image/File.php
@@ -2,9 +2,10 @@
 
 namespace Yireo\NextGenImages\Image;
 
+use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\Exception\FileSystemException;
-use Magento\Framework\Filesystem\DirectoryList;
-use Magento\Framework\Filesystem\Driver\File as FileDriver;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\DriverInterface;
 use Magento\Framework\View\Asset\File\NotFoundException;
 use Yireo\NextGenImages\Exception\ConvertorException;
 use Yireo\NextGenImages\Logger\Debugger;
@@ -17,9 +18,9 @@ class File
     private $directoryList;
 
     /**
-     * @var FileDriver
+     * @var DriverInterface
      */
-    private $fileDriver;
+    protected $fileDriver;
 
     /**
      * @var Debugger
@@ -35,18 +36,18 @@ class File
      * File constructor.
      *
      * @param DirectoryList $directoryList
-     * @param FileDriver $fileDriver
+     * @param Filesystem $filesystem
      * @param Debugger $debugger
      * @param UrlConvertor $urlConvertor
      */
     public function __construct(
         DirectoryList $directoryList,
-        FileDriver $fileDriver,
+        Filesystem $filesystem,
         Debugger $debugger,
         UrlConvertor $urlConvertor
     ) {
         $this->directoryList = $directoryList;
-        $this->fileDriver = $fileDriver;
+        $this->fileDriver = $filesystem->getDirectoryWrite(DirectoryList::PUB)->getDriver();
         $this->debugger = $debugger;
         $this->urlConvertor = $urlConvertor;
     }


### PR DESCRIPTION
While working on a plugin to integrate this module with Magento's RemoteStorage, we'd like to propose a few changes to increase the flexibility for such inheritance.

By using `Filesystem $filesystem`, a module can link this constructor parameter by their standard way:

```
    <type name="Yireo\NextGenImages\Image\File">
        <arguments>
            <argument name="filesystem" xsi:type="object">fullRemoteFilesystem</argument>
        </arguments>
    </type>
```

For the private properties, only the `$fileDriver` itself is most likely to be needed, hence the change from `private` to `protected`. With these changes the integration works correctly, although we're still in the process of testing the different features (most importantly the direct conversion on upload).