### PR TITLE
Use a positive lookahead for regex to also get overlapping matches.

### DIFF
--- a/Image/HtmlReplacer.php
+++ b/Image/HtmlReplacer.php
@@ -58,15 +58,20 @@ class HtmlReplacer
      */
     public function replaceImagesInHtml(LayoutInterface $layout, string $html): string
     {
-        $regex = '/<([^<]+)\ (data\-src|src)=\"([^\"]+)\.(png|jpg|jpeg)([^>]+)>(\s*)<(\/?)([a-z]+)/msi';
-        if (preg_match_all($regex, $html, $matches) === false) {
+        $groupRegex = '/(?=(<(?:[^<]+)\ (?:data\-src|src)=\"(?:[^\"]+)\.(?:png|jpg|jpeg)(?:[^>]+)>(?:\s*)<(?:\/?)(?:[a-z]+)))/msi';
+        if (preg_match_all($groupRegex, $html, $groups) === false) {
             return $html;
         }
 
-        foreach ($matches[0] as $index => $match) {
-            $nextTag = $matches[7][$index] . $matches[8][$index];
-            $fullSearchMatch = $matches[0][$index];
-            $imageUrl = $matches[3][$index] . '.' . $matches[4][$index];
+        $regex = '/<([^<]+)\ (data\-src|src)=\"([^\"]+)\.(png|jpg|jpeg)([^>]+)>(\s*)<(\/?)([a-z]+)/msi';
+        foreach ($groups[1] as $index => $match) {
+            if (preg_match($regex, $match, $matches) === false) {
+                continue;
+            }
+
+            $nextTag = $matches[7] . $matches[8];
+            $fullSearchMatch = $matches[0];
+            $imageUrl = $matches[3] . '.' . $matches[4];
 
             if (!$this->isAllowedByNextTag($nextTag)) {
                 continue;
@@ -81,7 +86,7 @@ class HtmlReplacer
                 continue;
             }
 
-            $isDataSrc = $matches[2][$index] === 'data-src';
+            $isDataSrc = $matches[2] === 'data-src';
             $htmlTag = preg_replace('/>(.*)/msi', '>', $fullSearchMatch);
             $newHtmlTag = $this->getNewHtmlTag($layout, $imageUrl, $sourceImages, $htmlTag, $isDataSrc);
             $replacement = $newHtmlTag . '<' . $nextTag;


### PR DESCRIPTION
I ran into an issue where not all images are being replaced when there are consecutive image tags. The first image would be replaced, but the second one would not. This happens because the first part of the second image tag (`<img`) is part of the first regex match.

I've changed the regex to also find overlapping matches using a 'positive lookahead'. Because lookaheads do not store/consume the match, another (with the original regex) `preg_match` has been added to actually find the matching parts.

This should solve https://github.com/yireo/Yireo_NextGenImages/issues/16 (and I suspect also https://github.com/yireo/Yireo_Webp2/issues/107), however as mentioned in https://github.com/yireo/Yireo_NextGenImages/issues/16#issuecomment-966884156 using a DOM parser might be more reliable.