### PR TITLE
Plugin's set order

### DIFF
--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\Framework\View\LayoutInterface">
-        <plugin name="yireo_nextgenimages_replace_tags" type="Yireo\NextGenImages\Plugin\ReplaceTagsPlugin"/>
+        <plugin name="yireo_nextgenimages_replace_tags" type="Yireo\NextGenImages\Plugin\ReplaceTagsPlugin" sortOrder="999" />
     </type>
 
     <type name="Magento\Swatches\Helper\Data">


### PR DESCRIPTION
To be sure to be executed in the first place for any other plugins which override the getOutput function.

As an example, to work with [m2-boilerplate/Module-Lazy-Load](https://github.com/m2-boilerplate/Module-Lazy-Load/), which is working with picture tag, this PR allow to launch first the plugin of your extension and the plugin of the LazyLoad function after (higher number execute first for the after plugin in Magento).
However, plugin of m2-boilerplate/Module-Lazy-Load is executed first and it is not working with your extension.

Not sure it is correct to include natively as we can create a custom module for every situation but setting a default sortOrder make sense.