### PR TITLE
Respect native lazy loading attribute

### DIFF
--- a/Block/PictureFactory.php
+++ b/Block/PictureFactory.php
@@ -55,7 +55,7 @@ class PictureFactory
             ->setWidth($this->getAttributeText($htmlTag, 'width'))
             ->setHeight($this->getAttributeText($htmlTag, 'height'))
             ->setOriginalTag($htmlTag)
-            ->setLazyLoading($this->config->addLazyLoading())
+            ->setLazyLoading($this->getAttributeText($htmlTag, 'loading') == "lazy" ?: $this->config->addLazyLoading())
             ->setIsDataSrc($isDataSrc)
             ->setDebug($this->config->isDebugging());
         return $block;


### PR DESCRIPTION
Respect the native lazy loading attribute of an image tag and use the setting as a fallback