### PR TITLE
adds catch for missing (local) image

### DIFF
--- a/Image/ImageCollector.php
+++ b/Image/ImageCollector.php
@@ -2,6 +2,7 @@
 
 namespace Yireo\NextGenImages\Image;
 
+use Magento\Framework\View\Asset\File\NotFoundException;
 use Yireo\NextGenImages\Convertor\ConvertorListing;
 use Yireo\NextGenImages\Exception\ConvertorException;
 use Yireo\NextGenImages\Logger\Debugger;
@@ -44,8 +45,15 @@ class ImageCollector
      */
     public function collect(string $imageUrl): array
     {
-        $image = $this->imageFactory->createFromUrl($imageUrl);
         $images = [];
+
+        try {
+            $image = $this->imageFactory->createFromUrl($imageUrl);
+        } catch (NotFoundException $e) {
+            $this->debugger->debug($e->getMessage(), ['url' => $imageUrl]);
+            return $images;
+        }
+        
         foreach ($this->convertorListing->getConvertors() as $convertor) {
             try {
                 $images[] = $convertor->convertImage($image);


### PR DESCRIPTION
If a local image does not exists, it should not throw an exception and blocks the page. 

![image](https://user-images.githubusercontent.com/15031079/169826860-f3f716ce-51d5-4f94-bc94-5b0ce0897ce9.png)
