### PR TITLE
fix: strip querystring from image url

### DIFF
--- a/Image/ImageFactory.php
+++ b/Image/ImageFactory.php
@@ -48,6 +48,10 @@ class ImageFactory
      */
     public function createFromUrl(string $url): Image
     {
+        if (strpos($url, 'http') !== false) {
+            $url = explode('?', $url)[0];
+        }
+
         $path = $this->urlConvertor->getFilenameFromUrl($url);
         return $this->objectManager->create(Image::class, ['path' => $path, 'url' => $url]);
     }


### PR DESCRIPTION
We use urls like `media/catalog/product/image/3369070ab6/some-image-name-70830.jpeg?width=700&height=700&store=ua&image-type=image` and the currently generated appropriate local file path includes querystring. To handle such files and keep hyva-related image urls like `fullscreen ? image.full : image.img` safely I suggest the solution below)