### PR TITLE
Fixed error 'Argument #1 () must not be empty' on PHP 8

### DIFF
--- a/Util/HtmlReplacer.php
+++ b/Util/HtmlReplacer.php
@@ -175,6 +175,9 @@ class HtmlReplacer
     private function htmlToDOMDocument(string $html): DOMDocument
     {
         $document = new DOMDocument();
+        if (empty($html)) {
+            return $document;
+        }
         libxml_use_internal_errors(true);
         $document->loadHTML(
             mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'),


### PR DESCRIPTION
This PR fixed the error that appears on PHP 8.x.

> ValueError: DOMDocument::loadHTML(): Argument #1 ($source) must not be empty in .../vendor/yireo/magento2-next-gen-images/Util/HtmlReplacer.php:138

My fix will ignore the process case of the empty HTML.