### PR TITLE
Fix for PHP 8.2 deprecated function call, replaced 'mb_convert_encodi…

### DIFF
--- a/Util/HtmlReplacer.php
+++ b/Util/HtmlReplacer.php
@@ -179,8 +179,16 @@ class HtmlReplacer
             return $document;
         }
         libxml_use_internal_errors(true);
+
+        $convmap = [0x80, 0x10FFFF, 0, 0x1FFFFF];
+        $encodedHtml = mb_encode_numericentity(
+            $html,
+            $convmap,
+            'UTF-8'
+        );
+
         $document->loadHTML(
-            mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'),
+            $encodedHtml,
             LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED
         );
         


### PR DESCRIPTION
…ng' with 'mb_encode_numericentity' the same way they did in Magento 2.4.6

See #54