### PR TITLE
Regression following 0.3.6

### DIFF
--- a/Util/UrlConvertor.php
+++ b/Util/UrlConvertor.php
@@ -62,7 +62,7 @@ class UrlConvertor
     public function isLocal(string $url): bool
     {
         $url = $this->normalizeUrl($url);
-        if (!preg_match('#^http://#', $url)) {
+        if (!preg_match('#^(http|https)://#', $url)) {
             return true;
         }
         
@@ -241,7 +241,6 @@ class UrlConvertor
     private function normalizeUrl(string $url): string
     {
         $url = str_replace('/index.php/', '/', $url);
-        $url = str_replace('https://', 'http://', $url);
         return preg_replace('#^//#', 'http://', $url);
     }
 }


### PR DESCRIPTION
Commit reference : 665e4f442e7c3893b02353580d44056cfce70479

Good afternoon,

Following version 0.3.6, the script is not working anymore on full https website (with redirection enabled on web server level).

Indeed, function normalizeUrl rewrites all URL submitted with http instead of https. When you call the config value through : 

```
$storeBaseUrl = $store->getBaseUrl(UrlInterface::URL_TYPE_WEB);
$storeMediaUrl = $store->getBaseUrl(UrlInterface::URL_TYPE_MEDIA);
$staticUrl = $store->getBaseUrl(UrlInterface::URL_TYPE_STATIC);
```

in _UrlConvertor_ class, it could definitively contain https string in it.

And so, when you do the test with _strpos_ it will always return _false_, so the entire extension will be disabled without any kind of error message.

I think the best way to support // link in my opinion is to do a check with _parse_url_ php function using scheme returning value test, and reconstruct the url with the correct scheme depending where it was called.

For now, this quick fix is working on a production website with https only.

Ilan