### PR TITLE
bugfix: add missing normalizeUrl to local-file-check

### DIFF
--- a/Util/UrlConvertor.php
+++ b/Util/UrlConvertor.php
@@ -67,17 +67,17 @@ class UrlConvertor
         }
         
         foreach ($this->storeManager->getStores() as $store) {
-            $storeBaseUrl = $store->getBaseUrl(UrlInterface::URL_TYPE_WEB);
+            $storeBaseUrl = $this->normalizeUrl($store->getBaseUrl(UrlInterface::URL_TYPE_WEB));
             if (strpos($url, $storeBaseUrl) !== false) {
                 return true;
             }
             
-            $storeMediaUrl = $store->getBaseUrl(UrlInterface::URL_TYPE_MEDIA);
+            $storeMediaUrl = $this->normalizeUrl($store->getBaseUrl(UrlInterface::URL_TYPE_MEDIA));
             if (strpos($url, $storeMediaUrl) !== false) {
                 return true;
             }
             
-            $storeStaticUrl = $store->getBaseUrl(UrlInterface::URL_TYPE_STATIC);
+            $storeStaticUrl = $this->normalizeUrl($store->getBaseUrl(UrlInterface::URL_TYPE_STATIC));
             if (strpos($url, $storeStaticUrl) !== false) {
                 return true;
             }
@@ -136,17 +136,17 @@ class UrlConvertor
         }
         
         foreach ($this->storeManager->getStores() as $store) {
-            $storeBaseUrl = $store->getBaseUrl(UrlInterface::URL_TYPE_WEB);
+            $storeBaseUrl = $this->normalizeUrl($store->getBaseUrl(UrlInterface::URL_TYPE_WEB));
             if (strpos($url, $storeBaseUrl) !== false) {
                 return str_replace($storeBaseUrl, $this->getBaseFolder() . '/', $url);
             }
             
-            $storeMediaUrl = $store->getBaseUrl(UrlInterface::URL_TYPE_MEDIA);
+            $storeMediaUrl = $this->normalizeUrl($store->getBaseUrl(UrlInterface::URL_TYPE_MEDIA));
             if (strpos($url, $storeMediaUrl) !== false) {
                 return str_replace($storeMediaUrl, $this->getMediaFolder() . '/', $url);
             }
             
-            $staticUrl = $store->getBaseUrl(UrlInterface::URL_TYPE_STATIC);
+            $staticUrl = $this->normalizeUrl($store->getBaseUrl(UrlInterface::URL_TYPE_STATIC));
             if (strpos($url, $staticUrl) !== false) {
                 return str_replace($staticUrl, $this->getStaticFolder() . '/', $url);
             }


### PR DESCRIPTION
if the domain is ssl protected, the url-converter will normalize the url to non-ssl-protected. 
but the compare against the store-url is still ssl-protected. 

so we need to normalize the base-urls too.