### PR TITLE
[FIX] add relative-path of source image to target-path if target is cache-folder

### DIFF
--- a/Image/TargetImageFactory.php
+++ b/Image/TargetImageFactory.php
@@ -87,7 +87,10 @@ class TargetImageFactory
     private function getTargetPathFromImage(Image $image): string
     {
         if ($this->config->getTargetDirectory() === TargetDirectory::CACHE) {
-            return $this->config->getCacheDirectoryPath();
+            $relativeImagePath = str_replace($this->directoryList->getRoot(), '', dirname($image->getPath()));
+            $relativeImagePath = str_replace('/pub', '', $relativeImagePath);
+            $relativeImagePath = preg_replace('#^/#', '', $relativeImagePath); // remove leading slash
+            return $this->config->getCacheDirectoryPath() . $relativeImagePath;
         }
 
         // phpcs:ignore


### PR DESCRIPTION
if an image exist with the same name on two different locations, the module may override the image. 

so we need a function to add the relative path to the target directory.

Feel free to add unit tests