### PR TITLE
issues/64: fix fetchpriority="high" has no effect

### DIFF
--- a/view/frontend/templates/picture.phtml
+++ b/view/frontend/templates/picture.phtml
@@ -9,14 +9,14 @@ $class = ($block->getClass()) ? ' class="' . $block->getClass() . '"' : '';
 $lazyLoading = ($block->getLazyLoading()) ? ' loading="lazy" ' : '';
 
 $originalTag = trim($block->getOriginalTag());
-$originalTag = preg_replace('/(\/?)>$/', $lazyLoading . '\1>', $originalTag);
-
-$originalImage = $block->getOriginalImage();
 
 if (strpos($originalTag, 'fetchpriority="high"')) {
     $lazyLoading = '';
 }
 
+$originalTag = preg_replace('/(\/?)>$/', $lazyLoading . '\1>', $originalTag);
+
+$originalImage = $block->getOriginalImage();
 $originalImageType = $block->getOriginalImageType();
 
 $srcsetAttribute = $block->getIsDataSrc() ? 'data-srcset' : 'srcset';


### PR DESCRIPTION
Related to this issue: https://github.com/yireo/Yireo_NextGenImages/issues/64

It's moving up the check for `fetchpriority="high"` so it's coming before the `preg_replace`, which is adding the lazyloading tag.
Fixes the functionality to disable lazyloading for specific images with `fetchpriority`.