### PR TITLE
Check for image extension in entire url instead of only at the end

### DIFF
--- a/Util/HtmlReplacer.php
+++ b/Util/HtmlReplacer.php
@@ -234,7 +234,7 @@ class HtmlReplacer
             return false;
         }
 
-        if (!preg_match('/\.(jpg|jpeg|png)$/', $imageUrl)) {
+        if (!preg_match('/\.(jpg|jpeg|png)/i', $imageUrl)) {
             return false;
         }
 


### PR DESCRIPTION
In Magento you can have parameters at the end of your product image url. You can find this functionality here: '\Magento\Catalog\Model\View\Asset\Image::getUrlWithTransformationParameters'

In the Yireo_NextGenImages module we currently check for an image-extension ('.jpg', '.jpeg', '.png') at the end of the url. But having an image-extension **not** at the end of your url should also be valid in this case. 