### PR TITLE
Fixed implicitly declared nullable arguments, improves compatibility …

### DIFF
--- a/Console/Command/ConvertCommand.php
+++ b/Console/Command/ConvertCommand.php
@@ -31,7 +31,7 @@ class ConvertCommand extends Command
     public function __construct(
         ConvertorListing $convertorListing,
         ImageFactory $imageFactory,
-        string $name = null
+        ?string $name = null
     ) {
         parent::__construct($name);
         $this->convertorListing = $convertorListing;

--- a/Console/Command/TestUriCommand.php
+++ b/Console/Command/TestUriCommand.php
@@ -17,7 +17,7 @@ class TestUriCommand extends Command
      * @var FileUtil
      */
     private $fileUtil;
-    
+
     /**
      * @var TargetImageFactory
      */
@@ -26,7 +26,7 @@ class TestUriCommand extends Command
      * @var ImageFactory
      */
     private $imageFactory;
-    
+
     /**
      * TestUriCommand constructor.
      * @param FileUtil $fileUtil
@@ -38,7 +38,7 @@ class TestUriCommand extends Command
         FileUtil $fileUtil,
         TargetImageFactory $targetImageFactory,
         ImageFactory $imageFactory,
-        string $name = null
+        ?string $name = null
     ) {
         parent::__construct($name);
         $this->fileUtil = $fileUtil;
@@ -76,23 +76,23 @@ class TestUriCommand extends Command
         $targetImage = $this->targetImageFactory->create($image, 'webp');
         $targetUri = $targetImage->getUrl();
         $targetPath = $this->fileUtil->resolve($targetUri);
-    
+
         $rows[] = ['Target path', $targetPath];
         $rows[] = ['Target exists', $this->getYesNo($this->fileUtil->uriExists($targetUri))];
         $modificationTime = $this->fileUtil->getModificationTime($targetPath);
         $modificationTimeFormatted = $modificationTime ? date('r', $modificationTime) : 'n/a';
         $rows[] = ['Target modification time', $modificationTimeFormatted];
-        
+
         $rows[] = ['Source is newer than target', $this->getYesNo($this->fileUtil->isNewerThan($path, $targetPath))];
-    
+
         $table = new Table($output);
         $table->setHeaders(['Check', 'Outcome']);
         $table->setRows($rows);
         $table->render();
-    
+
         return -1;
     }
-    
+
     /**
      * @param bool $value
      * @return string


### PR DESCRIPTION
…with PHP 8.4

When this module is installed on a Magento 2.4.8 shop in combination with PHP 8.4 and running `bin/magento`, it gives these warnings at the top:

```
$ bin/magento
PHP Deprecated:  Yireo\NextGenImages\Console\Command\TestUriCommand::__construct(): Implicitly marking parameter $name as nullable is deprecated, the explicit nullable type must be used instead in vendor/yireo/magento2-next-gen-images/Console/Command/TestUriCommand.php on line 37

Deprecated: Yireo\NextGenImages\Console\Command\TestUriCommand::__construct(): Implicitly marking parameter $name as nullable is deprecated, the explicit nullable type must be used instead in vendor/yireo/magento2-next-gen-images/Console/Command/TestUriCommand.php on line 37
PHP Deprecated:  Yireo\NextGenImages\Console\Command\ConvertCommand::__construct(): Implicitly marking parameter $name as nullable is deprecated, the explicit nullable type must be used instead in vendor/yireo/magento2-next-gen-images/Console/Command/ConvertCommand.php on line 31

Deprecated: Yireo\NextGenImages\Console\Command\ConvertCommand::__construct(): Implicitly marking parameter $name as nullable is deprecated, the explicit nullable type must be used instead in vendor/yireo/magento2-next-gen-images/Console/Command/ConvertCommand.php on line 31
Magento CLI 2.4.8
```

Ref: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

This PR fixes this.
