### PR TITLE
Remote storage support

### DIFF
--- a/Plugin/Convertor/ConvertorInterface.php
+++ b/Plugin/Convertor/ConvertorInterface.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yireo\NextGenImages\Plugin\Convertor;
+
+use Yireo\NextGenImages\Convertor\ConvertorInterface as BaseConvertorInterface;
+use Yireo\NextGenImages\Image\Image;
+
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Directory\TargetDirectory;
+use Filesystem\Directory\WriteInterface;
+use Yireo\NextGenImages\Image\TargetImageFactory;
+use Yireo\NextGenImages\Util\File;
+use Magento\RemoteStorage\Model\Config as RemoteStorageConfig;
+
+class ConvertorInterface
+{
+    private Filesystem\Directory\WriteInterface $tmpDirectoryWrite;
+    private Filesystem\Directory\WriteInterface $remoteDirectoryWrite;
+
+    private RemoteStorageConfig $remoteStorageConfig;
+
+    private TargetImageFactory $targetImageFactory;
+
+    private File $fileUtil;
+
+    public function __construct(
+        RemoteStorageConfig $remoteStorageConfig,
+        Filesystem $filesystem,
+        TargetDirectory $targetDirectory,
+        TargetImageFactory $targetImageFactory,
+        File $fileUtil,
+        private readonly \Krombox\YireoNextGenImages\Model\TmpFileCopier $tmpFileCopier,
+    ) {
+        $this->tmpDirectoryWrite = $filesystem->getDirectoryWrite(DirectoryList::TMP);
+        $this->remoteDirectoryWrite = $targetDirectory->getDirectoryWrite(DirectoryList::ROOT);
+        $this->remoteStorageConfig = $remoteStorageConfig;
+        $this->targetImageFactory = $targetImageFactory;
+        $this->fileUtil = $fileUtil;
+    }
+
+    public function aroundConvertImage(BaseConvertorInterface $subject, callable $proceed, Image $image): Image
+    {
+        if ($this->remoteStorageConfig->isEnabled() === false) {
+            return $proceed($image);
+        }
+
+        /* ATTENTION: Hardcoded format, I would add getFormat method to ConvertorInterface
+        and then use $subject->getFormat();*/
+        $format = 'webp'; // @TODO: Make this configurable.
+        $targetImage = $this->targetImageFactory->create($image, $format);
+
+        if (!$this->fileUtil->needsConversion($image->getPath(), $targetImage->getPath())) {
+            return $targetImage;
+        }
+        
+        $relativePath = $this->tmpDirectoryWrite->getRelativePath($image->getPath());
+        $this->tmpFileCopier->copy($relativePath);
+
+        $resultImage = $proceed($image);
+
+        $tmpAbsolutePath = $resultImage->getPath();
+
+        $tmpRelativePath = $this->tmpDirectoryWrite->getRelativePath($tmpAbsolutePath);
+
+        $remoteAbsolutePath = $this->remoteDirectoryWrite->getAbsolutePath($tmpRelativePath);
+
+        $this->moveToRemote($tmpAbsolutePath, $remoteAbsolutePath);
+
+        return $resultImage;
+    }
+
+    private function moveToRemote(string $localFile, string $remotePath): void
+    {
+        if ($this->tmpDirectoryWrite->getDriver()->isExists($localFile) === false) {
+            return;
+        }
+
+        $this->tmpDirectoryWrite->getDriver()->rename(
+            $localFile,
+            $remotePath,
+            $this->remoteDirectoryWrite->getDriver()
+        );
+    }
+}

--- a/Plugin/Util/File.php
+++ b/Plugin/Util/File.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yireo\NextGenImages\Plugin\Util;
+
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Directory\TargetDirectory;
+use Magento\Framework\Filesystem\Directory\ReadInterface;
+use Magento\RemoteStorage\Model\Config as RemoteStorageConfig;
+use Yireo\NextGenImages\Util\File as BaseFile;
+
+class File
+{
+    private ReadInterface $tmpDirectoryRead;
+
+    private ReadInterface $remoteDirectoryRead;
+
+    private RemoteStorageConfig $remoteStorageConfig;
+
+    public function __construct(
+        RemoteStorageConfig $remoteStorageConfig,
+        TargetDirectory $targetDirectory,
+        Filesystem $filesystem
+    ) {
+        $this->remoteStorageConfig = $remoteStorageConfig;
+        $this->tmpDirectoryRead = $filesystem->getDirectoryRead(DirectoryList::TMP);
+        $this->remoteDirectoryRead = $targetDirectory->getDirectoryRead(DirectoryList::ROOT);
+    }
+
+    public function aroundFileExists(
+        BaseFile $subject,
+        callable $proceed,
+        string $filePath
+    ): bool {
+        if (!$this->remoteStorageConfig->isEnabled()) {
+            return $proceed($filePath);
+        }
+
+        $relativePath = $this->tmpDirectoryRead->getRelativePath($filePath);
+        
+        return $this->remoteDirectoryRead->isExist($relativePath);
+    }
+
+    public function aroundGetModificationTime(BaseFile $subject, callable $proceed, string $filePath): int
+    {
+        if (!$this->remoteStorageConfig->isEnabled()) {
+            return $proceed($filePath);
+        }
+
+        $tmpRelativePath = $this->tmpDirectoryRead->getRelativePath($filePath);
+        $stat = $this->remoteDirectoryRead->stat($tmpRelativePath);
+
+        return (int)($stat['mtime'] ?? $stat['ctime'] ?? 0);
+    }
+}

--- a/Plugin/Util/UrlConvertor.php
+++ b/Plugin/Util/UrlConvertor.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yireo\NextGenImages\Plugin\Util;
+
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Exception\FileSystemException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Filesystem\Driver\File;
+use Magento\Framework\Exception\NotFoundException;
+use Magento\RemoteStorage\Model\Config as RemoteStorageConfig;
+use Yireo\NextGenImages\Util\UrlConvertor as BaseUrlConvertor;
+
+class UrlConvertor
+{
+    /**
+     * @var RemoteStorageConfig
+     */
+    private $remoteStorageConfig;
+
+    /**
+     * @var File
+     */
+    private $fileDriver;
+
+    /**
+     * @var string
+     */
+    private $basePath;
+
+    /**
+     * @var string
+     */
+    private $mediaPath;
+
+    /**
+     * @var string
+     */
+    private $staticPath;
+
+    /**
+     * @var string
+     */
+    private $tmpBasePath;
+
+    /**
+     * @var string
+     */
+    private $tmpMediaPath;
+
+    /**
+     * @var string
+     */
+    private $tmpStaticPath;
+
+    public function __construct(
+        RemoteStorageConfig $remoteStorageConfig,
+        DirectoryList $directoryList,
+        File $fileDriver
+    ) {
+        $this->remoteStorageConfig = $remoteStorageConfig;
+        $this->fileDriver = $fileDriver;
+
+        $this->basePath = rtrim($directoryList->getRoot(), '/');
+        $this->mediaPath = rtrim($directoryList->getPath(DirectoryList::MEDIA), '/');
+        $this->staticPath = rtrim($directoryList->getPath(DirectoryList::STATIC_VIEW), '/');
+
+        $this->tmpBasePath = rtrim($directoryList->getPath(DirectoryList::TMP), '/');
+        $this->tmpMediaPath = $this->tmpBasePath . '/' . DirectoryList::MEDIA;
+        $this->tmpStaticPath = $this->tmpBasePath . '/' . DirectoryList::STATIC_VIEW;
+    }
+
+    /**
+     * Replaces Magento folders with their var/tmp equivalents.
+     */
+    public function afterGetFilenameFromUrl(BaseUrlConvertor $subject, string $result): string
+    {
+        if ($this->remoteStorageConfig->isEnabled() === false) {
+            return $result;
+        }
+
+        try {
+            $realMediaPath = $this->fileDriver->getRealPath($this->mediaPath);
+            if (strpos($result, $realMediaPath) !== false) {
+                return str_replace($this->mediaPath, $this->tmpMediaPath, $result);
+            }
+        } catch (FileSystemException|NoSuchEntityException $e) {
+            throw new NotFoundException(__('Media folder does not exist'));
+        }
+
+        try {
+            $realStaticPath = $this->fileDriver->getRealPath($this->staticPath);
+            if (strpos($result, $realStaticPath) !== false) {
+                return str_replace($this->staticPath, $this->tmpStaticPath, $result);
+            }
+        } catch (FileSystemException|NoSuchEntityException $e) {
+            throw new NotFoundException(__('Static folder does not exist'));
+        }
+
+        try {
+            $realBasePath = $this->fileDriver->getRealPath($this->basePath);
+            if (strpos($result, $realBasePath) !== false) {
+                return str_replace($this->basePath, $this->tmpBasePath, $result);
+            }
+        } catch (FileSystemException $e) {
+            throw new NotFoundException(__('Base folder does not exist'));
+        }
+
+        return $result;
+    }
+
+    /**
+     * Replaces var/tmp folders with Magento folders.
+     */
+    public function beforeGetUrlFromFilename(BaseUrlConvertor $subject, string $filename): array
+    {
+        if ($this->remoteStorageConfig->isEnabled() === false) {
+            return [$filename];
+        }
+
+        if (strpos($filename, $this->tmpMediaPath) !== false) {
+            $filename = str_replace($this->tmpMediaPath, $this->mediaPath, $filename);
+        }
+
+        if (strpos($filename, $this->tmpStaticPath) !== false) {
+            $filename = str_replace($this->tmpStaticPath, $this->staticPath, $filename);
+        }
+
+        if (strpos($filename, $this->tmpBasePath) !== false) {
+            $filename = str_replace($this->tmpBasePath, $this->basePath, $filename);
+        }
+
+        return [$filename];
+    }
+}

--- a/Util/TmpFileCopier.php
+++ b/Util/TmpFileCopier.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yireo\NextGenImages\Util;
+
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\Exception\FileSystemException;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Directory\WriteInterface;
+use Magento\Framework\Filesystem\Directory\TargetDirectory;
+use Magento\RemoteStorage\Model\Config as RemoteStorageConfig;
+use Psr\Log\LoggerInterface;
+
+class TmpFileCopier
+{
+    private WriteInterface $tmpDirectoryWrite;
+    private WriteInterface $remoteDirectoryWrite;
+    private Filesystem $filesystem;
+    private TargetDirectory $targetDirectory;
+    private RemoteStorageConfig $remoteStorageConfig;
+    private LoggerInterface $logger;
+
+    /**
+     * Map of remote path => local tmp absolute path.
+     *
+     * @var array<string,string>
+     */
+    private array $tmpFiles = [];
+
+    public function __construct(
+        Filesystem $filesystem,
+        TargetDirectory $targetDirectory,
+        RemoteStorageConfig $remoteStorageConfig,
+        LoggerInterface $logger
+    ) {
+        $this->filesystem = $filesystem;
+        $this->targetDirectory = $targetDirectory;
+        $this->remoteStorageConfig = $remoteStorageConfig;
+        $this->logger = $logger;
+        $this->tmpDirectoryWrite = $this->filesystem->getDirectoryWrite(DirectoryList::TMP);
+        $this->remoteDirectoryWrite = $this->targetDirectory->getDirectoryWrite(DirectoryList::ROOT);
+    }
+
+    /**
+     * Removes created tmp files
+     */
+    public function __destruct()
+    {
+        try {
+            foreach ($this->tmpFiles as $key => $tmpFile) {
+                $this->tmpDirectoryWrite->delete($tmpFile);
+                unset($this->tmpFiles[$key]);
+            }
+        } catch (\Exception $e) {
+            $this->logger->error($e->getMessage());
+        }
+    }
+
+    public function copy(string $filePath): string
+    {
+        if ($this->remoteStorageConfig->isEnabled() === false) {
+            return $filePath;
+        }
+
+        if (isset($this->tmpFiles[$filePath])) {
+            return $this->tmpFiles[$filePath];
+        }
+
+        $absolutePath = $this->remoteDirectoryWrite->getAbsolutePath($filePath);
+
+        if ($this->remoteDirectoryWrite->isFile($absolutePath)) {
+            $tmpPath = $this->tmpDirectoryWrite->getAbsolutePath($filePath);
+
+            $parentDir = $this->tmpDirectoryWrite->getDriver()->getParentDirectory($tmpPath);
+            $this->tmpDirectoryWrite->create($parentDir);
+
+            $content = $this->remoteDirectoryWrite->getDriver()->fileGetContents($filePath);
+
+            if ($this->tmpDirectoryWrite->getDriver()->filePutContents($tmpPath, $content) >= 0) {
+                $filePath = $tmpPath;
+                $this->tmpFiles[$tmpPath] = $tmpPath;
+            }
+        }
+
+        return $filePath;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -42,4 +42,15 @@
             </argument>
         </arguments>
     </type>
+
+    <type name="Yireo\NextGenImages\Convertor\ConvertorInterface">
+        <plugin name="Yireo_NextGenImages::convertorInterface" type="Yireo\NextGenImages\Plugin\Convertor\ConvertorInterface" />
+    </type>
+
+    <type name="Yireo\NextGenImages\Util\File">
+        <plugin name="Yireo_NextGenImages::file" type="Yireo\NextGenImages\Plugin\Util\File" />
+    </type>
+    <type name="Yireo\NextGenImages\Util\UrlConvertor">
+        <plugin name="Yireo_NextGenImages::urlConvertor" type="Yireo\NextGenImages\Plugin\Util\UrlConvertor" />
+    </type>
 </config>


### PR DESCRIPTION
Adds support for Magento's [Remote Storage](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/storage/remote-storage/remote-storage) driver across converters.

This addresses the remote storage limitation previously discussed in [Yireo_Webp2#139](https://github.com/yireo/Yireo_Webp2/issues/139). 

Instead of adding support specifically to `Webp2`'s `ConvertWrapper` (which would tie the implementation strictly to WebP), this solution targets `Yireo_NextGenImages`. By targeting `ConvertorInterface` via plugins, the remote storage capability is applied generically across present and future converter implementations (WebP, AVIF, etc.).

To fully decouple format handling, `ConvertorInterface` could ideally expose a format getter (e.g., `getFormat(): string`). Currently, `$format = 'webp'` is temporarily hardcoded in the plugin to avoid introducing breaking changes to the interface.
If you are open to expanding `ConvertorInterface` (or have another approach in mind), I would be glad to adjust the PR based on your feedback!